### PR TITLE
Add vineyard to the shm benchmark

### DIFF
--- a/shm_distributed/conftest.py
+++ b/shm_distributed/conftest.py
@@ -1,30 +1,37 @@
 import os
 import subprocess
 import shlex
+import shutil
+import sys
 import time
 
 import pytest
+
+
+plasma_path = "/tmp/plasma"
+lmdb_path = "/tmp/lmdb"
+vineyard_path = "/tmp/vineyard.sock"
 
 
 @pytest.fixture()
 def lmdb_deleter():
     import shutil
     try:
-        os.mkdir("/tmp/lmdb")
+        os.mkdir(lmdb_path)
     except OSError:
         pass
 
     yield
-    shutil.rmtree("/tmp/lmdb")
-
-
-path = "/tmp/plasma"
+    shutil.rmtree(lmdb_path)
 
 
 @pytest.fixture(scope="module")
 def plasma_process():
     pytest.importorskip("pyarrow.plasma")
-    cmd = shlex.split(f"plasma-store-server -m 10000000000 -s {path}")  # 10MB
+    plasma_exe = 'plasma-store-server'
+    if shutil.which(plasma_exe) is None:
+        plasma_exe = 'plasma_store'
+    cmd = shlex.split(f"{plasma_exe} -m 10000000000 -s {plasma_path}")  # 10MB
     proc = subprocess.Popen(cmd, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
     yield proc
     proc.terminate()
@@ -38,7 +45,7 @@ def plasma_session(plasma_process):
     timeout = 10
     while True:
         try:
-            client = plasma.connect(path)
+            client = plasma.connect(plasma_path)
             client.list()
             break
         except (ValueError, TypeError, RuntimeError):
@@ -49,3 +56,34 @@ def plasma_session(plasma_process):
     client.evict(1000000)
     yield client
     client.evict(1000000)
+
+
+@pytest.fixture(scope="module")
+def vineyard_process():
+    pytest.importorskip("vineyard")
+    cmd = [sys.executable, '-m', 'vineyard',
+           '--socket', vineyard_path,
+           '--size', '10000000000',
+           '--meta', 'local']
+    proc = subprocess.Popen(cmd)
+    yield
+    proc.terminate()
+    proc.wait()
+
+
+@pytest.fixture()
+def vineyard_session(vineyard_process):
+    import vineyard
+
+    timeout = 10
+    while True:
+        try:
+            client = vineyard.connect(vineyard_path)
+            if client.connected:
+                break
+        except (ValueError, TypeError, RuntimeError):
+            timeout -= 0.1
+            if timeout < 0:
+                raise RuntimeError
+            time.sleep(0.1)
+    yield client

--- a/shm_distributed/test_runs.py
+++ b/shm_distributed/test_runs.py
@@ -72,9 +72,9 @@ def worker_scatter_workflow(client: distributed.Client):
     return f, result
 
 
-@pytest.mark.parametrize("ser", ["pickle", "lmdb", "plasma"])
+@pytest.mark.parametrize("ser", ["pickle", "plasma", "vineyard"])
 @pytest.mark.parametrize("workflow", [client_scatter_workflow, worker_scatter_workflow])
-def test_workflow(ser, workflow, lmdb_deleter, plasma_session):
+def test_workflow(ser, workflow, lmdb_deleter, plasma_session, vineyard_session):
     client = distributed.Client(
         n_workers=4,
         threads_per_worker=1,
@@ -84,9 +84,9 @@ def test_workflow(ser, workflow, lmdb_deleter, plasma_session):
 
     # ensure our config got through
     pids = list(client.run(os.getpid).values()) + [os.getpid()]
-    if ser == "plasma":
+    if ser == "plasma" or ser == "vineyard":
         for proc in psutil.process_iter():
-            if "plasma" in proc.name().lower():
+            if "plasma" in proc.name().lower() or "vineyard" in proc.name().lower():
                 pids.append(proc.pid)
                 break
     start_mem = memories(pids)


### PR DESCRIPTION
The number looks not well, and it does work and I would look into the number further.

Edit: I have made a mistake in the "cache" part of vineyard implementation. After the bug fixed vineyard looks faster than plasma and I think there are still much optimization spaces inside the vineyard itself.

The difference comes from the performance difference of `_put_vineyard_buffer` and `_put_plasma_buffer`. I have added a timing decorator in https://github.com/martindurant/distributed/pull/2.

Hope the above information could be helpful.

```
shm_distributed/test_runs.py::test_workflow[client_scatter_workflow-pickle] 7.540348s
Start: 742 resident, 516 unique
Start: 4844 resident, 4618 unique
Δmem: 4127
PASSED
shm_distributed/test_runs.py::test_workflow[client_scatter_workflow-plasma] 1.174548s
Start: 766 resident, 526 unique
Start: 1793 resident, 1552 unique
Δmem: 6
PASSED
shm_distributed/test_runs.py::test_workflow[client_scatter_workflow-vineyard] 0.915509s
Start: 1792 resident, 1551 unique
Start: 2818 resident, 2577 unique
Δmem: 5
PASSED
shm_distributed/test_runs.py::test_workflow[worker_scatter_workflow-pickle] 10.160269s
Start: 2795 resident, 2568 unique
Start: 6906 resident, 6679 unique
Δmem: 4134
PASSED
shm_distributed/test_runs.py::test_workflow[worker_scatter_workflow-plasma] 3.202961s
Start: 2826 resident, 2585 unique
Start: 4875 resident, 2586 unique
Δmem: 1033
PASSED
shm_distributed/test_runs.py::test_workflow[worker_scatter_workflow-vineyard] 3.288973s
Start: 2827 resident, 2586 unique
Start: 10000 resident, 3615 unique
Δmem: 1045
```

------------------------------------------------------------

Address #2